### PR TITLE
[FEAT] Create Persistence Layer

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeHotReload)
+    alias(libs.plugins.ksp)
 }
 
 kotlin {
@@ -32,6 +33,7 @@ kotlin {
             implementation(libs.compose.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
+            implementation(libs.androidx.room.runtime)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
@@ -72,6 +74,8 @@ android {
 
 dependencies {
     debugImplementation(libs.compose.uiTooling)
+    add("kspAndroid", libs.androidx.room.compiler)
+    add("kspJvm", libs.androidx.room.compiler)
 }
 
 compose.desktop {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -11,6 +11,10 @@ plugins {
 }
 
 kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
+
     androidTarget {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
@@ -34,6 +38,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(libs.androidx.room.runtime)
+            implementation(libs.androidx.sqlite.bundled)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -47,6 +47,9 @@ kotlin {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutinesSwing)
         }
+        jvmTest.dependencies {
+            implementation(libs.kotlinx.coroutines.core)
+        }
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/com/innowise/newsfeed/data/local/DatabaseBuilder.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/innowise/newsfeed/data/local/DatabaseBuilder.android.kt
@@ -1,0 +1,14 @@
+package com.innowise.newsfeed.data.local
+
+import android.content.Context
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+fun getDatabaseBuilder(context: Context): RoomDatabase.Builder<NewsDatabase> {
+    val appContext = context.applicationContext
+    val dbFile = appContext.getDatabasePath(NewsDatabase.DATABASE_NAME)
+    return Room.databaseBuilder<NewsDatabase>(
+        context = appContext,
+        name = dbFile.absolutePath,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/NewsDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/NewsDatabase.kt
@@ -1,11 +1,15 @@
 package com.innowise.newsfeed.data.local
 
+import androidx.room.ConstructedBy
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.RoomDatabaseConstructor
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.innowise.newsfeed.data.local.dao.ArticleDao
 import com.innowise.newsfeed.data.local.entity.ArticleEntity
 
 @Database(entities = [ArticleEntity::class], version = 1, exportSchema = false)
+@ConstructedBy(NewsDatabaseConstructor::class)
 abstract class NewsDatabase : RoomDatabase() {
     abstract fun articleDao(): ArticleDao
 
@@ -13,3 +17,10 @@ abstract class NewsDatabase : RoomDatabase() {
         const val DATABASE_NAME = "news.db"
     }
 }
+
+expect object NewsDatabaseConstructor : RoomDatabaseConstructor<NewsDatabase>
+
+fun getNewsDatabase(builder: RoomDatabase.Builder<NewsDatabase>): NewsDatabase =
+    builder
+        .setDriver(BundledSQLiteDriver())
+        .build()

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/NewsDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/NewsDatabase.kt
@@ -6,13 +6,17 @@ import androidx.room.RoomDatabase
 import androidx.room.RoomDatabaseConstructor
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.innowise.newsfeed.data.local.dao.ArticleDao
+import com.innowise.newsfeed.data.local.dao.BookmarkDao
 import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import com.innowise.newsfeed.data.local.entity.BookmarkEntity
 import kotlinx.coroutines.Dispatchers
 
-@Database(entities = [ArticleEntity::class], version = 1, exportSchema = false)
+@Database(entities = [ArticleEntity::class, BookmarkEntity::class], version = 1, exportSchema = false)
 @ConstructedBy(NewsDatabaseConstructor::class)
 abstract class NewsDatabase : RoomDatabase() {
     abstract fun articleDao(): ArticleDao
+
+    abstract fun bookmarkDao(): BookmarkDao
 
     companion object {
         const val DATABASE_NAME = "news.db"

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/NewsDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/NewsDatabase.kt
@@ -7,6 +7,7 @@ import androidx.room.RoomDatabaseConstructor
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.innowise.newsfeed.data.local.dao.ArticleDao
 import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import kotlinx.coroutines.Dispatchers
 
 @Database(entities = [ArticleEntity::class], version = 1, exportSchema = false)
 @ConstructedBy(NewsDatabaseConstructor::class)
@@ -23,4 +24,5 @@ expect object NewsDatabaseConstructor : RoomDatabaseConstructor<NewsDatabase>
 fun getNewsDatabase(builder: RoomDatabase.Builder<NewsDatabase>): NewsDatabase =
     builder
         .setDriver(BundledSQLiteDriver())
+        .setQueryCoroutineContext(Dispatchers.IO)
         .build()

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/NewsDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/NewsDatabase.kt
@@ -1,0 +1,15 @@
+package com.innowise.newsfeed.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.innowise.newsfeed.data.local.dao.ArticleDao
+import com.innowise.newsfeed.data.local.entity.ArticleEntity
+
+@Database(entities = [ArticleEntity::class], version = 1, exportSchema = false)
+abstract class NewsDatabase : RoomDatabase() {
+    abstract fun articleDao(): ArticleDao
+
+    companion object {
+        const val DATABASE_NAME = "news.db"
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/dao/ArticleDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/dao/ArticleDao.kt
@@ -11,7 +11,7 @@ interface ArticleDao {
     @Upsert
     suspend fun upsertArticles(articles: List<ArticleEntity>)
 
-    @Query("SELECT * FROM articles")
+    @Query("SELECT * FROM articles ORDER BY publishedTimestamp DESC")
     fun getArticles(): Flow<List<ArticleEntity>>
 
     @Query("SELECT * FROM articles WHERE id = :id")

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/dao/ArticleDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/dao/ArticleDao.kt
@@ -1,0 +1,22 @@
+package com.innowise.newsfeed.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ArticleDao {
+    @Upsert
+    suspend fun upsertArticles(articles: List<ArticleEntity>)
+
+    @Query("SELECT * FROM articles")
+    fun getArticles(): Flow<List<ArticleEntity>>
+
+    @Query("SELECT * FROM articles WHERE id = :id")
+    suspend fun getArticleById(id: Long): ArticleEntity?
+
+    @Query("DELETE FROM articles")
+    suspend fun clear()
+}

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/dao/ArticleDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/dao/ArticleDao.kt
@@ -16,7 +16,4 @@ interface ArticleDao {
 
     @Query("SELECT * FROM articles WHERE id = :id")
     suspend fun getArticleById(id: Long): ArticleEntity?
-
-    @Query("DELETE FROM articles")
-    suspend fun clear()
 }

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/dao/BookmarkDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/dao/BookmarkDao.kt
@@ -1,0 +1,28 @@
+package com.innowise.newsfeed.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import com.innowise.newsfeed.data.local.entity.BookmarkEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BookmarkDao {
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertBookmark(bookmark: BookmarkEntity)
+
+    @Query("DELETE FROM bookmarks WHERE articleId = :articleId")
+    suspend fun deleteBookmark(articleId: Long)
+
+    @Query(
+        "SELECT articles.* FROM articles " +
+            "INNER JOIN bookmarks ON articles.id = bookmarks.articleId " +
+            "ORDER BY bookmarks.id DESC",
+    )
+    fun getBookmarkedArticles(): Flow<List<ArticleEntity>>
+
+    @Query("SELECT articleId FROM bookmarks")
+    fun getBookmarkedIds(): Flow<List<Long>>
+}

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/entity/ArticleEntity.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/entity/ArticleEntity.kt
@@ -1,0 +1,17 @@
+package com.innowise.newsfeed.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "articles")
+data class ArticleEntity(
+    @PrimaryKey val id: Long,
+    val title: String,
+    val description: String?,
+    val url: String?,
+    val coverImageUrl: String?,
+    val publishedTimestamp: String?,
+    val readingTimeMinutes: Int?,
+    val authorName: String?,
+    val tags: String,
+)

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/entity/BookmarkEntity.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/local/entity/BookmarkEntity.kt
@@ -1,0 +1,14 @@
+package com.innowise.newsfeed.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "bookmarks",
+    indices = [Index(value = ["articleId"], unique = true)],
+)
+data class BookmarkEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val articleId: Long,
+)

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/mapper/ArticleMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/mapper/ArticleMapper.kt
@@ -1,0 +1,28 @@
+package com.innowise.newsfeed.data.mapper
+
+import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import com.innowise.newsfeed.domain.model.Article
+
+fun ArticleEntity.toDomain(): Article = Article(
+    id = id,
+    title = title,
+    description = description.orEmpty(),
+    url = url.orEmpty(),
+    coverImageUrl = coverImageUrl.orEmpty(),
+    publishedTimestamp = publishedTimestamp.orEmpty(),
+    readingTimeMinutes = readingTimeMinutes ?: 0,
+    authorName = authorName.orEmpty(),
+    tags = tags,
+)
+
+fun Article.toEntity(): ArticleEntity = ArticleEntity(
+    id = id,
+    title = title,
+    description = description,
+    url = url,
+    coverImageUrl = coverImageUrl,
+    publishedTimestamp = publishedTimestamp,
+    readingTimeMinutes = readingTimeMinutes,
+    authorName = authorName,
+    tags = tags,
+)

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/repository/BookmarksRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/repository/BookmarksRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.innowise.newsfeed.data.repository
+
+import com.innowise.newsfeed.data.local.dao.BookmarkDao
+import com.innowise.newsfeed.data.local.entity.BookmarkEntity
+import com.innowise.newsfeed.data.mapper.toDomain
+import com.innowise.newsfeed.domain.model.Article
+import com.innowise.newsfeed.domain.repository.BookmarksRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class BookmarksRepositoryImpl(
+    private val bookmarkDao: BookmarkDao,
+) : BookmarksRepository {
+    override fun getBookmarkedArticles(): Flow<List<Article>> =
+        bookmarkDao.getBookmarkedArticles().map { entities -> entities.map { it.toDomain() } }
+
+    override fun getBookmarkedIds(): Flow<Set<Long>> =
+        bookmarkDao.getBookmarkedIds().map { it.toSet() }
+
+    override suspend fun setBookmarked(articleId: Long, bookmarked: Boolean) {
+        if (bookmarked) {
+            bookmarkDao.insertBookmark(BookmarkEntity(articleId = articleId))
+        } else {
+            bookmarkDao.deleteBookmark(articleId)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.innowise.newsfeed.data.repository
+
+import com.innowise.newsfeed.data.local.dao.ArticleDao
+import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import com.innowise.newsfeed.domain.repository.LocalNewsRepository
+import kotlinx.coroutines.flow.Flow
+
+class LocalNewsRepositoryImpl(
+    private val articleDao: ArticleDao,
+) : LocalNewsRepository {
+    override fun getArticles(): Flow<List<ArticleEntity>> =
+        articleDao.getArticles()
+
+    override suspend fun getArticle(articleId: Long): ArticleEntity? =
+        articleDao.getArticleById(articleId)
+
+    override suspend fun saveArticles(articles: List<ArticleEntity>) =
+        articleDao.upsertArticles(articles)
+}

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImpl.kt
@@ -1,19 +1,22 @@
 package com.innowise.newsfeed.data.repository
 
 import com.innowise.newsfeed.data.local.dao.ArticleDao
-import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import com.innowise.newsfeed.data.mapper.toDomain
+import com.innowise.newsfeed.data.mapper.toEntity
+import com.innowise.newsfeed.domain.model.Article
 import com.innowise.newsfeed.domain.repository.LocalNewsRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class LocalNewsRepositoryImpl(
     private val articleDao: ArticleDao,
 ) : LocalNewsRepository {
-    override fun getArticles(): Flow<List<ArticleEntity>> =
-        articleDao.getArticles()
+    override fun getArticles(): Flow<List<Article>> =
+        articleDao.getArticles().map { entities -> entities.map { it.toDomain() } }
 
-    override suspend fun getArticle(articleId: Long): ArticleEntity? =
-        articleDao.getArticleById(articleId)
+    override suspend fun getArticle(articleId: Long): Article? =
+        articleDao.getArticleById(articleId)?.toDomain()
 
-    override suspend fun saveArticles(articles: List<ArticleEntity>) =
-        articleDao.upsertArticles(articles)
+    override suspend fun saveArticles(articles: List<Article>) =
+        articleDao.upsertArticles(articles.map(Article::toEntity))
 }

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/domain/model/Article.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/domain/model/Article.kt
@@ -1,0 +1,13 @@
+package com.innowise.newsfeed.domain.model
+
+data class Article(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val url: String,
+    val coverImageUrl: String,
+    val publishedTimestamp: String,
+    val readingTimeMinutes: Int,
+    val authorName: String,
+    val tags: String,
+)

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/domain/repository/BookmarksRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/domain/repository/BookmarksRepository.kt
@@ -1,0 +1,12 @@
+package com.innowise.newsfeed.domain.repository
+
+import com.innowise.newsfeed.domain.model.Article
+import kotlinx.coroutines.flow.Flow
+
+interface BookmarksRepository {
+    fun getBookmarkedArticles(): Flow<List<Article>>
+
+    fun getBookmarkedIds(): Flow<Set<Long>>
+
+    suspend fun setBookmarked(articleId: Long, bookmarked: Boolean)
+}

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/domain/repository/LocalNewsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/domain/repository/LocalNewsRepository.kt
@@ -1,12 +1,12 @@
 package com.innowise.newsfeed.domain.repository
 
-import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import com.innowise.newsfeed.domain.model.Article
 import kotlinx.coroutines.flow.Flow
 
 interface LocalNewsRepository {
-    fun getArticles(): Flow<List<ArticleEntity>>
+    fun getArticles(): Flow<List<Article>>
 
-    suspend fun getArticle(articleId: Long): ArticleEntity?
+    suspend fun getArticle(articleId: Long): Article?
 
-    suspend fun saveArticles(articles: List<ArticleEntity>)
+    suspend fun saveArticles(articles: List<Article>)
 }

--- a/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/domain/repository/LocalNewsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/innowise/newsfeed/domain/repository/LocalNewsRepository.kt
@@ -1,0 +1,12 @@
+package com.innowise.newsfeed.domain.repository
+
+import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import kotlinx.coroutines.flow.Flow
+
+interface LocalNewsRepository {
+    fun getArticles(): Flow<List<ArticleEntity>>
+
+    suspend fun getArticle(articleId: Long): ArticleEntity?
+
+    suspend fun saveArticles(articles: List<ArticleEntity>)
+}

--- a/composeApp/src/jvmMain/kotlin/com/innowise/newsfeed/data/local/DatabaseBuilder.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/innowise/newsfeed/data/local/DatabaseBuilder.jvm.kt
@@ -1,0 +1,13 @@
+package com.innowise.newsfeed.data.local
+
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import java.io.File
+
+fun getDatabaseBuilder(): RoomDatabase.Builder<NewsDatabase> {
+    val appDir = File(System.getProperty("user.home"), ".newsfeed").apply { mkdirs() }
+    val dbFile = File(appDir, NewsDatabase.DATABASE_NAME)
+    return Room.databaseBuilder<NewsDatabase>(
+        name = dbFile.absolutePath,
+    )
+}

--- a/composeApp/src/jvmMain/kotlin/com/innowise/newsfeed/data/local/DatabaseBuilder.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/innowise/newsfeed/data/local/DatabaseBuilder.jvm.kt
@@ -5,7 +5,8 @@ import androidx.room.RoomDatabase
 import java.io.File
 
 fun getDatabaseBuilder(): RoomDatabase.Builder<NewsDatabase> {
-    val appDir = File(System.getProperty("user.home"), ".newsfeed").apply { mkdirs() }
+    val userHome = System.getProperty("user.home") ?: "."
+    val appDir = File(userHome, ".newsfeed").apply { mkdirs() }
     val dbFile = File(appDir, NewsDatabase.DATABASE_NAME)
     return Room.databaseBuilder<NewsDatabase>(
         name = dbFile.absolutePath,

--- a/composeApp/src/jvmTest/kotlin/com/innowise/newsfeed/data/repository/BookmarksRepositoryImplTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/innowise/newsfeed/data/repository/BookmarksRepositoryImplTest.kt
@@ -1,0 +1,94 @@
+package com.innowise.newsfeed.data.repository
+
+import androidx.room.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import com.innowise.newsfeed.data.local.NewsDatabase
+import com.innowise.newsfeed.domain.model.Article
+import com.innowise.newsfeed.domain.repository.BookmarksRepository
+import com.innowise.newsfeed.domain.repository.LocalNewsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BookmarksRepositoryImplTest {
+
+    private lateinit var database: NewsDatabase
+    private lateinit var localNewsRepository: LocalNewsRepository
+    private lateinit var repository: BookmarksRepository
+
+    @BeforeTest
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder<NewsDatabase>()
+            .setDriver(BundledSQLiteDriver())
+            .setQueryCoroutineContext(Dispatchers.IO)
+            .build()
+        localNewsRepository = LocalNewsRepositoryImpl(database.articleDao())
+        repository = BookmarksRepositoryImpl(database.bookmarkDao())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun setBookmarkedAddsAndRemovesBookmark() = runBlocking {
+        localNewsRepository.saveArticles(listOf(article(1), article(2)))
+
+        repository.setBookmarked(1, true)
+        assertEquals(setOf(1L), repository.getBookmarkedIds().first())
+        assertEquals(listOf(article(1)), repository.getBookmarkedArticles().first())
+
+        repository.setBookmarked(1, false)
+        assertEquals(emptySet(), repository.getBookmarkedIds().first())
+    }
+
+    @Test
+    fun setBookmarkedTwiceKeepsSingleBookmark() = runBlocking {
+        localNewsRepository.saveArticles(listOf(article(1)))
+
+        repository.setBookmarked(1, true)
+        repository.setBookmarked(1, true)
+
+        assertEquals(setOf(1L), repository.getBookmarkedIds().first())
+        assertEquals(1, repository.getBookmarkedArticles().first().size)
+    }
+
+    @Test
+    fun bookmarkSurvivesArticleRefresh() = runBlocking {
+        localNewsRepository.saveArticles(listOf(article(1)))
+        repository.setBookmarked(1, true)
+
+        val refreshed = article(1).copy(title = "Updated title")
+        localNewsRepository.saveArticles(listOf(refreshed, article(2)))
+
+        assertEquals(setOf(1L), repository.getBookmarkedIds().first())
+        assertEquals(listOf(refreshed), repository.getBookmarkedArticles().first())
+    }
+
+    @Test
+    fun getBookmarkedArticlesOrdersByLatestBookmarkedFirst() = runBlocking {
+        localNewsRepository.saveArticles(listOf(article(1), article(2)))
+
+        repository.setBookmarked(1, true)
+        repository.setBookmarked(2, true)
+
+        assertEquals(listOf(article(2), article(1)), repository.getBookmarkedArticles().first())
+    }
+
+    private fun article(id: Long) = Article(
+        id = id,
+        title = "Title $id",
+        description = "Description $id",
+        url = "https://dev.to/$id",
+        coverImageUrl = "",
+        publishedTimestamp = "",
+        readingTimeMinutes = 0,
+        authorName = "Author $id",
+        tags = "kotlin",
+    )
+}

--- a/composeApp/src/jvmTest/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImplTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImplTest.kt
@@ -3,7 +3,7 @@ package com.innowise.newsfeed.data.repository
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.innowise.newsfeed.data.local.NewsDatabase
-import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import com.innowise.newsfeed.domain.model.Article
 import com.innowise.newsfeed.domain.repository.LocalNewsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -54,14 +54,14 @@ class LocalNewsRepositoryImplTest {
         assertNull(repository.getArticle(1))
     }
 
-    private fun article(id: Long) = ArticleEntity(
+    private fun article(id: Long) = Article(
         id = id,
         title = "Title $id",
         description = "Description $id",
         url = "https://dev.to/$id",
-        coverImageUrl = null,
-        publishedTimestamp = null,
-        readingTimeMinutes = null,
+        coverImageUrl = "",
+        publishedTimestamp = "",
+        readingTimeMinutes = 0,
         authorName = "Author $id",
         tags = "kotlin",
     )

--- a/composeApp/src/jvmTest/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImplTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImplTest.kt
@@ -35,11 +35,23 @@ class LocalNewsRepositoryImplTest {
 
     @Test
     fun saveArticlesThenGetArticlesEmitsSaved() = runBlocking {
-        val articles = listOf(article(1), article(2))
+        val older = article(1, publishedTimestamp = "2026-01-01T10:00:00Z")
+        val newer = article(2, publishedTimestamp = "2026-02-01T10:00:00Z")
 
-        repository.saveArticles(articles)
+        repository.saveArticles(listOf(older, newer))
 
-        assertEquals(articles, repository.getArticles().first())
+        assertEquals(listOf(older, newer), repository.getArticles().first().sortedBy { it.id })
+    }
+
+    @Test
+    fun getArticlesOrdersByPublishedTimestampDesc() = runBlocking {
+        val older = article(1, publishedTimestamp = "2026-01-01T10:00:00Z")
+        val newest = article(2, publishedTimestamp = "2026-03-01T10:00:00Z")
+        val middle = article(3, publishedTimestamp = "2026-02-01T10:00:00Z")
+
+        repository.saveArticles(listOf(older, newest, middle))
+
+        assertEquals(listOf(newest, middle, older), repository.getArticles().first())
     }
 
     @Test
@@ -54,13 +66,16 @@ class LocalNewsRepositoryImplTest {
         assertNull(repository.getArticle(1))
     }
 
-    private fun article(id: Long) = Article(
+    private fun article(
+        id: Long,
+        publishedTimestamp: String = "",
+    ) = Article(
         id = id,
         title = "Title $id",
         description = "Description $id",
         url = "https://dev.to/$id",
         coverImageUrl = "",
-        publishedTimestamp = "",
+        publishedTimestamp = publishedTimestamp,
         readingTimeMinutes = 0,
         authorName = "Author $id",
         tags = "kotlin",

--- a/composeApp/src/jvmTest/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImplTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/innowise/newsfeed/data/repository/LocalNewsRepositoryImplTest.kt
@@ -1,0 +1,68 @@
+package com.innowise.newsfeed.data.repository
+
+import androidx.room.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import com.innowise.newsfeed.data.local.NewsDatabase
+import com.innowise.newsfeed.data.local.entity.ArticleEntity
+import com.innowise.newsfeed.domain.repository.LocalNewsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LocalNewsRepositoryImplTest {
+
+    private lateinit var database: NewsDatabase
+    private lateinit var repository: LocalNewsRepository
+
+    @BeforeTest
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder<NewsDatabase>()
+            .setDriver(BundledSQLiteDriver())
+            .setQueryCoroutineContext(Dispatchers.IO)
+            .build()
+        repository = LocalNewsRepositoryImpl(database.articleDao())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun saveArticlesThenGetArticlesEmitsSaved() = runBlocking {
+        val articles = listOf(article(1), article(2))
+
+        repository.saveArticles(articles)
+
+        assertEquals(articles, repository.getArticles().first())
+    }
+
+    @Test
+    fun getArticleReturnsSavedArticle() = runBlocking {
+        repository.saveArticles(listOf(article(7)))
+
+        assertEquals(article(7), repository.getArticle(7))
+    }
+
+    @Test
+    fun getArticleMissingIdReturnsNull() = runBlocking {
+        assertNull(repository.getArticle(1))
+    }
+
+    private fun article(id: Long) = ArticleEntity(
+        id = id,
+        title = "Title $id",
+        description = "Description $id",
+        url = "https://dev.to/$id",
+        coverImageUrl = null,
+        publishedTimestamp = null,
+        readingTimeMinutes = null,
+        authorName = "Author $id",
+        tags = "kotlin",
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ kotlinx-coroutines = "1.10.2"
 ksp = "2.3.9"
 material3 = "1.10.0-alpha05"
 room = "2.8.4"
+sqlite = "2.6.2"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -39,6 +40,7 @@ compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-previ
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMul
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,9 @@ composeMultiplatform = "1.10.3"
 junit = "4.13.2"
 kotlin = "2.3.20"
 kotlinx-coroutines = "1.10.2"
+ksp = "2.3.9"
 material3 = "1.10.0-alpha05"
+room = "2.8.4"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -35,6 +37,8 @@ compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMul
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -43,3 +47,4 @@ composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "com
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
Добавлен Room KMP (driver, KSP) в commonMain, ArticleEntity и таблица articles                                                                                                                                                                                                                                                
Добавлен ArticleDao с upsert, получением списка (Flow) и выборкой по id                                                                                                           
Добавлена NewsDatabase и NewsDatabaseConstructor (expect/actual)                                                                                                                  
Подключён BundledSQLiteDriver через getNewsDatabase и добавлены платформенные билдеры БД для Android и JVM                                                                                                                                                   
Добавлен LocalNewsRepository и LocalNewsRepositoryImpl для работы с БД из data layer                                                                                              
Добавлен JVM test, который проверяет сохранение и чтение через in-memory БД             